### PR TITLE
rm broken datadex from dataStorage, add Git-RDM

### DIFF
--- a/sections/dataStorage/index.md
+++ b/sections/dataStorage/index.md
@@ -19,7 +19,7 @@ There are many options for data storing depending on duration, data type, and st
 ### Data Package Manager
 
 - [dat](http://dat-data.com)
-- [datadex.io](http://datadex.io)
+- [Git-RDM](https://github.com/ctjacobs/git-rdm)
 
 ##Resources
 


### PR DESCRIPTION
It seems that `datadex` is not an active project (or at least I could not find it). The datadex.io link on the `dataStorage` page is broken. I wonder if a link to [Git-RDM](https://github.com/ctjacobs/git-rdm) could be added? 
