### PR TITLE
Fix a markdown syntax boo-boo

### DIFF
--- a/sections/introduction/index.md
+++ b/sections/introduction/index.md
@@ -11,7 +11,7 @@ Modern challenges of reproducibility in research, particularly computational rep
 
 In this short introduction, we briefly summarise some of the principles, definitions and questions relevant to reproducible research that have emerged in the literature. We outline basic and widely applicable steps for promoting reproducibility. While our suggestions for tools and workflow are aimed primarily at the computational environment of the R programming language, the principles and definitions sketched out here are applicable to researchers working in any environment. You are welcome to contribute to this guide (fix typos, add to the [reference list](https://github.com/ropensci/reproducibility-guide/blob/gh-pages/sections/references/index.md), etc.) by submitting a pull request to its [github repository](https://github.com/ropensci/reproducibility-guide). 
 
-If you're not familiar with R, have a look at [rforcats.net] (http://rforcats.net/) for a gentle introduction, and if you're already working with R then have a look at Hadley's [Advanced R programming book](http://adv-r.had.co.nz/) for a guide to best practices. 
+If you're not familiar with R, have a look at [rforcats.net](http://rforcats.net/) for a gentle introduction, and if you're already working with R then have a look at Hadley's [Advanced R programming book](http://adv-r.had.co.nz/) for a guide to best practices. 
 
 # Why do reproducible research? 
 


### PR DESCRIPTION
There was a space between a link text and hyperlink address. We should remove it.
